### PR TITLE
feat: augmented search command to support max_retries and min_retry_wait

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -24,6 +24,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tox tox-gh-actions
+        pip install tox==3.28.0 tox-gh-actions
     - name: Test with tox
       run: tox

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ pytest-cov==3.0.0
 isort==5.10.1
 black== 22.3.0
 flake8==4.0.1
+tox==3.28.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 httpx==0.23.0
 fire==0.4.0
+tenacity==8.2.2

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read_requirements(path="requirements.txt"):
 
 setup(
     name="ghs",
-    version="1.0.0",
+    version="1.1.0",
     description="GitHub scripts",
     author="AmLight Team",
     author_email="no-reply@amlight.net",


### PR DESCRIPTION
Closes #6 

Augmented search command to support `--max_retries=MAX_RETRIES` and `--min_retry_wait=MIN_RETRY_WAIT`. By default, it'll retry three times waiting for at least 65 secs each time, aligned with the current quotas of the search GH endpoint. 

```
ghs search --help
```

```
NAME
    ghs search - Search issues and PRs, the query_expr is an expression that GitHub search supports such as 'org:some_org label:some_label'.

SYNOPSIS
    ghs search QUERY_EXPR <flags>

DESCRIPTION
    Search issues and PRs, the query_expr is an expression that GitHub search supports such as 'org:some_org label:some_label'.

POSITIONAL ARGUMENTS
    QUERY_EXPR
        Type: str

FLAGS
    --max_retries=MAX_RETRIES
        Type: int
        Default: 3
    --min_retry_wait=MIN_RETRY_WAIT
        Type: int
        Default: 65

NOTES
    You can also use flags syntax for POSITIONAL ARGUMENTS

```

Version `1.1.0` just got bumped. 

Since this is a CLI for developers, the traceback will still be shown if max retries is reached.
