### PR TITLE
feat: added `repo_issue_create` and `org_repos_issue_create` concurrent  funcs

### DIFF
--- a/ghs/client.py
+++ b/ghs/client.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from .issue_client import org_repos_issue_create, repo_issue_create  # noqa
 from .label_client import (  # noqa
     org_repos_default_labels_create,
     org_repos_labels,

--- a/ghs/issue_client.py
+++ b/ghs/issue_client.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import asyncio
+from typing import List
+
+import httpx
+
+from .base import base_url, headers
+from .repo_client import org_repos_by_attr
+
+
+async def repo_issue_create(
+    owner: str,
+    repo: str,
+    title: str,
+    body: str = "",
+    assignees: List[str] = None,
+    labels: List[str] = None,
+) -> dict:
+    """Create an issue in a repository."""
+    assignees = assignees if assignees else []
+    labels = labels if labels else []
+    url = f"{base_url()}/repos/{owner}/{repo}/issues"
+    async with httpx.AsyncClient() as client:
+        r = await client.post(
+            url,
+            headers=headers(),
+            json={
+                "title": title,
+                "body": body,
+                "assignees": assignees,
+                "labels": labels,
+            },
+        )
+        r.raise_for_status()
+        rbody = r.json()
+        return {
+            "number": rbody.get("number"),
+            "title": rbody.get("title"),
+            "html_url": rbody.get("html_url"),
+        }
+
+
+async def org_repos_issue_create(
+    org: str,
+    title: str,
+    body: str = "",
+    assignees: List[str] = None,
+    labels: List[str] = None,
+    included_repos: List[str] = None,
+):
+    """Create an issue in repos of an org."""
+    repos = await org_repos_by_attr(org, "name", included_repos)
+    coros = [
+        repo_issue_create(org, repo, title, body, assignees, labels) for repo in repos
+    ]
+    results = await asyncio.gather(*coros)
+    return {repo: result for repo, result in zip(repos, results)}

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read_requirements(path="requirements.txt"):
 
 setup(
     name="ghs",
-    version="1.1.0",
+    version="1.2.0",
     description="GitHub scripts",
     author="AmLight Team",
     author_email="no-reply@amlight.net",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import pytest
 from tests.data import repo_labels_data as _repo_labels_data
 from tests.data import repos_data as _repos_data
 from tests.data import search_issues_data as _search_issues_data
+from tests.data import repo_issue_data as _repos_issue_data
 
 
 @pytest.fixture
@@ -22,3 +23,8 @@ def repo_labels_data() -> List[dict]:
 @pytest.fixture
 def search_issues_data() -> dict:
     return _search_issues_data()
+
+
+@pytest.fixture
+def repo_issue_data() -> dict:
+    return _repos_issue_data()

--- a/tests/data.py
+++ b/tests/data.py
@@ -619,3 +619,77 @@ def search_issues_data() -> dict:
             },
         ],
     }
+
+
+def repo_issue_data() -> dict:
+    """repo isso data."""
+    return {
+        "id": 1,
+        "node_id": "MDU6SXNzdWUx",
+        "url": "https://api.github.com/repos/octocat/Hello-World/issues/1347",
+        "repository_url": "https://api.github.com/repos/octocat/Hello-World",
+        "labels_url": "https://api.github.com/repos/octocat/Hello-World/issues/1347/labels{/name}",
+        "comments_url": "https://api.github.com/repos/octocat/Hello-World/issues/1347/comments",
+        "events_url": "https://api.github.com/repos/octocat/Hello-World/issues/1347/events",
+        "html_url": "https://github.com/octocat/Hello-World/issues/1347",
+        "number": 1347,
+        "state": "open",
+        "title": "Found a bug",
+        "body": "I'm having a problem with this.",
+        "user": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+        },
+        "labels": [
+            {
+                "id": 208045946,
+                "node_id": "MDU6TGFiZWwyMDgwNDU5NDY=",
+                "url": "https://api.github.com/repos/octocat/Hello-World/labels/bug",
+                "name": "bug",
+                "description": "Something isn't working",
+                "color": "f29513",
+            }
+        ],
+        "assignees": [
+            {
+                "login": "octocat",
+                "id": 1,
+                "node_id": "MDQ6VXNlcjE=",
+                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/octocat",
+                "html_url": "https://github.com/octocat",
+                "followers_url": "https://api.github.com/users/octocat/followers",
+                "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+                "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+                "organizations_url": "https://api.github.com/users/octocat/orgs",
+                "repos_url": "https://api.github.com/users/octocat/repos",
+                "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/octocat/received_events",
+                "type": "User",
+            }
+        ],
+        "active_lock_reason": "too heated",
+        "comments": 0,
+        "closed_at": None,
+        "created_at": "2011-04-22T13:33:48Z",
+        "updated_at": "2011-04-22T13:33:48Z",
+        "state_reason": "completed",
+    }

--- a/tests/test_issue_client.py
+++ b/tests/test_issue_client.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import respx
+from httpx import Response
+
+from ghs.base import base_url
+from ghs.issue_client import repo_issue_create
+
+
+async def test_repo_issue_create(respx_mock, repo_issue_data) -> None:
+    with respx.mock(base_url=base_url()) as respx_mock:
+        owner = "kytos-ng"
+        repo = "kytos"
+        respx_mock.post(f"/repos/{owner}/{repo}/issues").mock(
+            return_value=Response(200, json=repo_issue_data)
+        )
+        response = await repo_issue_create(owner, repo, "some title")
+        assert response["number"] == repo_issue_data["number"]
+        assert response["title"] == repo_issue_data["title"]
+        assert response["html_url"] == repo_issue_data["html_url"]


### PR DESCRIPTION
Closes #5 

In addition to unit tests I also tested it in practice on kytos-ng org, for instance, here three issues were created in bulk concurrently on `kytos`, `of_core` and `mef_eline`:

https://github.com/kytos-ng/of_core/issues/106
https://github.com/kytos-ng/kytos/issues/344
https://github.com/kytos-ng/mef_eline/issues/295