### PR TITLE
feat: added search_issues_rm_label command

### DIFF
--- a/ghs/client.py
+++ b/ghs/client.py
@@ -14,4 +14,4 @@ from .label_client import (  # noqa
     repo_labels_delete,
 )
 from .repo_client import org_repos, org_repos_by_attr  # noqa
-from .search_client import search, search_issues_add_labels  # noqa
+from .search_client import search, search_issues_add_labels, search_issues_rm_label  # noqa

--- a/ghs/client.py
+++ b/ghs/client.py
@@ -14,4 +14,8 @@ from .label_client import (  # noqa
     repo_labels_delete,
 )
 from .repo_client import org_repos, org_repos_by_attr  # noqa
-from .search_client import search, search_issues_add_labels, search_issues_rm_label  # noqa
+from .search_client import (
+    search,
+    search_issues_add_labels,
+    search_issues_rm_label,
+)  # noqa

--- a/ghs/client.py
+++ b/ghs/client.py
@@ -14,8 +14,8 @@ from .label_client import (  # noqa
     repo_labels_delete,
 )
 from .repo_client import org_repos, org_repos_by_attr  # noqa
-from .search_client import (
+from .search_client import (  # noqa
     search,
     search_issues_add_labels,
     search_issues_rm_label,
-)  # noqa
+)

--- a/ghs/label_client.py
+++ b/ghs/label_client.py
@@ -165,3 +165,13 @@ async def add_labels(
             url, headers=headers(), json=[str(label) for label in labels]
         )
         return {"status_code": r.status_code, "response": r.json()}
+
+
+async def remove_label(
+    owner: str, repo: str, issue_number: Union[int, str], label: str
+) -> dict:
+    """Remove a label of an issue."""
+    url = f"{base_url()}/repos/{owner}/{repo}/issues/{issue_number}/labels/{label}"
+    async with httpx.AsyncClient() as client:
+        r = await client.delete(url, headers=headers())
+        return {"status_code": r.status_code, "response": r.json()}

--- a/ghs/search_client.py
+++ b/ghs/search_client.py
@@ -17,7 +17,7 @@ from tenacity import (
 )
 
 from .base import base_url, headers
-from .label_client import add_labels
+from .label_client import add_labels, remove_label
 
 
 def _build_args(dict_args, kv_sep="=", arg_sep="&") -> str:
@@ -145,6 +145,22 @@ async def search_issues_add_labels(query_expr: str, labels: List[str]) -> dict:
         html_url = result.get("html_url", "").split("/")
         owner, repo = html_url[-4], html_url[-3]
         coros.append(add_labels(owner, repo, number, labels))
+        ids.append(result.get("html_url"))
+    results = await asyncio.gather(*coros)
+    return {key: result.get("status_code") for key, result in zip(ids, results)}
+
+
+async def search_issues_rm_label(query_expr: str, label: str) -> dict:
+    """Remove a label of issues given a search query_expr"""
+    results = await search(query_expr)
+    results = json.loads(results)
+    coros = []
+    ids = []
+    for result in results.get("items", []):
+        number = result.get("number")
+        html_url = result.get("html_url", "").split("/")
+        owner, repo = html_url[-4], html_url[-3]
+        coros.append(remove_label(owner, repo, number, label))
         ids.append(result.get("html_url"))
     results = await asyncio.gather(*coros)
     return {key: result.get("status_code") for key, result in zip(ids, results)}

--- a/tests/test_label_client.py
+++ b/tests/test_label_client.py
@@ -8,6 +8,7 @@ from httpx import Response
 from ghs.base import base_url
 from ghs.label_client import (
     add_labels,
+    remove_label,
     org_repos_default_labels_create,
     org_repos_labels,
     org_repos_labels_create,
@@ -222,3 +223,17 @@ async def test_add_labels(respx_mock, repo_labels_data) -> None:
             owner, repo, issue_number, [label.get("name") for label in repo_labels_data]
         )
         assert len(repo_labels_data) == len(list(response.get("response")))
+
+
+async def test_rm_label(respx_mock, repo_labels_data) -> None:
+    with respx.mock(base_url=base_url()) as respx_mock:
+        data = [repo_labels_data[0]]
+        owner = "kytos-ng"
+        repo = "flow_manager"
+        label = "some_label"
+        issue_number = 10
+        respx_mock.delete(
+            f"/repos/{owner}/{repo}/issues/{issue_number}/labels/{label}"
+        ).mock(return_value=Response(200, json=data))
+        response = await remove_label(owner, repo, issue_number, label)
+        assert len(data) == len(list(response.get("response")))


### PR DESCRIPTION
Added new command `search_issues_rm_label`

```
     search_issues_rm_label
       Remove a label of issues given a search query_expr
```

### Local test

```
❯ ghs search_issues_rm_label 'org:kytos-ng is:issue label:2024.2' 2024.2
{}
```

Used it to remove given 2024.2 labels before setting with 2025.1